### PR TITLE
Fix issue #23 in green-park-2

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -17,6 +17,19 @@
         <img src="<?php echo get_stylesheet_directory_uri(); ?>/img/logo-cgp2.png" alt="Cordobo Green Park 2 Beta 0.9.9" title="Version: Cordobo Green Park 2 Beta 0.9.9" width="75" height="12" />
     </p>
 
+    <?php
+    // Display custom footer menu if assigned
+    if (has_nav_menu('footer_menu')) {
+        wp_nav_menu(array(
+            'theme_location' => 'footer_menu',
+            'container' => 'nav',
+            'container_class' => 'footer-navigation',
+            'menu_class' => 'footer-menu',
+            'fallback_cb' => false
+        ));
+    }
+    ?>
+
 </div>
 
 <?php wp_footer(); ?>

--- a/header.php
+++ b/header.php
@@ -14,43 +14,57 @@
 <div id="header">
 
     <?php if (greenpark2_get_option('accessibility_disable') != true) : ?>
-        <ul id="accessibility">
-            <?php if (greenpark2_get_option('accessibility_home') != true) : ?>
-                <li>
-                    <a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php esc_attr_e('Go to homepage', 'greenpark'); ?>">
-                        <?php esc_html_e('Home', 'greenpark'); ?>
-                    </a>
-                </li>
-            <?php endif; ?>
+        <?php
+        // Check if a custom accessibility menu has been assigned
+        if (has_nav_menu('accessibility_menu')) {
+            wp_nav_menu(array(
+                'theme_location' => 'accessibility_menu',
+                'container' => false,
+                'menu_id' => 'accessibility',
+                'menu_class' => '',
+                'fallback_cb' => false
+            ));
+        } else {
+            // Fallback to hardcoded accessibility links if no menu is assigned
+            ?>
+            <ul id="accessibility">
+                <?php if (greenpark2_get_option('accessibility_home') != true) : ?>
+                    <li>
+                        <a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php esc_attr_e('Go to homepage', 'greenpark'); ?>">
+                            <?php esc_html_e('Home', 'greenpark'); ?>
+                        </a>
+                    </li>
+                <?php endif; ?>
 
-            <?php if (greenpark2_get_option('accessibility_content') != 'yes') : ?>
-                <li>
-                    <a href="#content" title="<?php esc_attr_e('Skip to content', 'greenpark'); ?>">
-                        <?php esc_html_e('Content', 'greenpark'); ?>
-                    </a>
-                </li>
-            <?php endif; ?>
+                <?php if (greenpark2_get_option('accessibility_content') != 'yes') : ?>
+                    <li>
+                        <a href="#content" title="<?php esc_attr_e('Skip to content', 'greenpark'); ?>">
+                            <?php esc_html_e('Content', 'greenpark'); ?>
+                        </a>
+                    </li>
+                <?php endif; ?>
 
-            <?php if (greenpark2_get_option('accessibility_feed') != 'yes') : ?>
-                <li>
-                    <a href="<?php
-                        if (greenpark2_get_option('feed_enable') == 'yes') {
-                            echo esc_url('https://feeds.feedburner.com/' . greenpark2_get_option('feed_uri'));
-                        } else {
-                            echo esc_url(get_bloginfo('rss2_url'));
-                        }
-                    ?>">
-                        <?php esc_html_e('RSS', 'greenpark'); ?>
-                    </a>
-                </li>
-            <?php endif; ?>
+                <?php if (greenpark2_get_option('accessibility_feed') != 'yes') : ?>
+                    <li>
+                        <a href="<?php
+                            if (greenpark2_get_option('feed_enable') == 'yes') {
+                                echo esc_url('https://feeds.feedburner.com/' . greenpark2_get_option('feed_uri'));
+                            } else {
+                                echo esc_url(get_bloginfo('rss2_url'));
+                            }
+                        ?>">
+                            <?php esc_html_e('RSS', 'greenpark'); ?>
+                        </a>
+                    </li>
+                <?php endif; ?>
 
-            <?php if (greenpark2_get_option('accessibility_loginout') != 'yes') : ?>
-                <li class="last-item">
-                    <?php wp_loginout(); ?>
-                </li>
-            <?php endif; ?>
-        </ul>
+                <?php if (greenpark2_get_option('accessibility_loginout') != 'yes') : ?>
+                    <li class="last-item">
+                        <?php wp_loginout(); ?>
+                    </li>
+                <?php endif; ?>
+            </ul>
+        <?php } ?>
     <?php endif; ?>
 
     <div id="branding" role="banner">

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,6 +1,20 @@
 <div id="sidebar">
 <ul class="sb-list clearfix">
 
+<?php
+// Display custom sidebar menu if assigned
+if (has_nav_menu('sidebar_menu')) {
+    echo '<li class="sidebar-menu">';
+    wp_nav_menu(array(
+        'theme_location' => 'sidebar_menu',
+        'container' => 'div',
+        'container_class' => 'sidebar-nav-menu',
+        'menu_class' => 'sidebar-nav',
+        'fallback_cb' => false
+    ));
+    echo '</li>';
+}
+?>
 
 <?php
 $options = get_option( 'cgp2_theme_options' );


### PR DESCRIPTION
This commit implements the three previously registered but unused menu locations:
- accessibility_menu: Added to header.php with fallback to existing hardcoded links
- sidebar_menu: Added to sidebar.php, displays at top when assigned
- footer_menu: Added to footer.php, displays before closing footer div

All implementations use has_nav_menu() to check if a menu is assigned before displaying, ensuring backward compatibility. Users can now customize these menus through the WordPress admin interface.

Resolves issue #23 - WordPress Menus "register_nav_menus" fix