### PR TITLE
Add edit functionality for logged-in users

### DIFF
--- a/header.php
+++ b/header.php
@@ -63,6 +63,14 @@ if ( function_exists( 'wp_body_open' ) ) {
                     </li>
                 <?php endif; ?>
 
+                <?php if (get_theme_mod('greenpark_accessibility_edit') != 'yes' && is_user_logged_in() && is_singular() && current_user_can('edit_post', get_the_ID())) : ?>
+                    <li>
+                        <a href="<?php echo esc_url(get_edit_post_link()); ?>" title="<?php esc_attr_e('Edit this page', 'greenpark'); ?>">
+                            <?php esc_html_e('Edit', 'greenpark'); ?>
+                        </a>
+                    </li>
+                <?php endif; ?>
+
                 <?php if (get_theme_mod('greenpark_accessibility_loginout') != 'yes') : ?>
                     <li class="last-item">
                         <?php wp_loginout(); ?>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -44,6 +44,84 @@ function greenpark_customize_register( $wp_customize ) {
 
 
 	// -------------------------------------------------------------------------
+	// Accessibility Section
+	// -------------------------------------------------------------------------
+	$wp_customize->add_section( 'greenpark_accessibility_section', array(
+		'title'       => __( 'Accessibility Links', 'greenpark' ),
+		'priority'    => 35,
+		'description' => __( 'Configure the accessibility navigation strip at the top of the page.', 'greenpark' ),
+	) );
+
+	$wp_customize->add_setting( 'greenpark_accessibility_disable', array(
+		'default'           => false,
+		'sanitize_callback' => 'greenpark_sanitize_checkbox',
+	) );
+
+	$wp_customize->add_control( 'greenpark_accessibility_disable', array(
+		'label'       => __( 'Disable All Accessibility Links', 'greenpark' ),
+		'description' => __( 'Hide the entire accessibility navigation strip.', 'greenpark' ),
+		'section'     => 'greenpark_accessibility_section',
+		'type'        => 'checkbox',
+	) );
+
+	$wp_customize->add_setting( 'greenpark_accessibility_home', array(
+		'default'           => false,
+		'sanitize_callback' => 'greenpark_sanitize_checkbox',
+	) );
+
+	$wp_customize->add_control( 'greenpark_accessibility_home', array(
+		'label'    => __( 'Hide Home Link', 'greenpark' ),
+		'section'  => 'greenpark_accessibility_section',
+		'type'     => 'checkbox',
+	) );
+
+	$wp_customize->add_setting( 'greenpark_accessibility_content', array(
+		'default'           => false,
+		'sanitize_callback' => 'greenpark_sanitize_checkbox',
+	) );
+
+	$wp_customize->add_control( 'greenpark_accessibility_content', array(
+		'label'    => __( 'Hide Content Link', 'greenpark' ),
+		'section'  => 'greenpark_accessibility_section',
+		'type'     => 'checkbox',
+	) );
+
+	$wp_customize->add_setting( 'greenpark_accessibility_feed', array(
+		'default'           => false,
+		'sanitize_callback' => 'greenpark_sanitize_checkbox',
+	) );
+
+	$wp_customize->add_control( 'greenpark_accessibility_feed', array(
+		'label'    => __( 'Hide RSS Link', 'greenpark' ),
+		'section'  => 'greenpark_accessibility_section',
+		'type'     => 'checkbox',
+	) );
+
+	$wp_customize->add_setting( 'greenpark_accessibility_edit', array(
+		'default'           => false,
+		'sanitize_callback' => 'greenpark_sanitize_checkbox',
+	) );
+
+	$wp_customize->add_control( 'greenpark_accessibility_edit', array(
+		'label'       => __( 'Hide Edit Link', 'greenpark' ),
+		'description' => __( 'The Edit link only appears for logged-in users with edit permissions.', 'greenpark' ),
+		'section'     => 'greenpark_accessibility_section',
+		'type'        => 'checkbox',
+	) );
+
+	$wp_customize->add_setting( 'greenpark_accessibility_loginout', array(
+		'default'           => false,
+		'sanitize_callback' => 'greenpark_sanitize_checkbox',
+	) );
+
+	$wp_customize->add_control( 'greenpark_accessibility_loginout', array(
+		'label'    => __( 'Hide Login/Logout Link', 'greenpark' ),
+		'section'  => 'greenpark_accessibility_section',
+		'type'     => 'checkbox',
+	) );
+
+
+	// -------------------------------------------------------------------------
 	// Layout Section
 	// -------------------------------------------------------------------------
 	$wp_customize->add_section( 'greenpark_layout_section', array(


### PR DESCRIPTION
Add an "Edit" link to the site strip (accessibility navigation) that appears when:
- User is logged in
- Viewing a singular post or page
- User has permission to edit the current post/page

The edit link can be disabled via the new Accessibility Links section in the WordPress Customizer. Also added complete accessibility section to customizer to control all accessibility navigation links.